### PR TITLE
Option to exclude user from lists is missing from wp-admin - FIXED

### DIFF
--- a/admin/settings/class-settings.php
+++ b/admin/settings/class-settings.php
@@ -577,6 +577,13 @@ class UsersWP_Admin_Settings {
                             'options' =>   $this->uwp_available_users_layout(),
                             'placeholder' => __( 'Select Layout', 'userswp' )
                         ),
+                        'users_excluded_from_list' => array(
+                            'id' => 'users_excluded_from_list',
+                            'name' => __( 'Users to exclude', 'userswp' ),
+                            'type' => 'text',
+                            'std' => '',
+                            'desc' 	=> __( 'Enter comma separated ids of users to exclude from users listing.', 'userswp' ),
+                        ),
                     )
                 ),
                 'change' => apply_filters( 'uwp_settings_general_change',

--- a/includes/helpers/misc.php
+++ b/includes/helpers/misc.php
@@ -309,10 +309,17 @@ function get_uwp_users_list() {
     $inactive_users = new WP_User_Query($arg);
     $exclude_users = $inactive_users->get_results();
 
+    $excluded_globally = uwp_get_option('users_excluded_from_list');
+    if ( $excluded_globally ) {
+        $users = str_replace(' ', '', $excluded_globally );
+        $users_array = explode(',', $users );
+        $exclude_users = array_merge($exclude_users, $users_array);
+    }
+
     $exclude_users = apply_filters('uwp_excluded_users_from_list', $exclude_users, $where, $keyword);
 
     if($exclude_users){
-        $exclude_users_list = implode(',', $exclude_users);
+        $exclude_users_list = implode(',', array_unique($exclude_users));
         $exclude_query = 'AND '. $wpdb->users.'.ID NOT IN ('.$exclude_users_list.')';
     } else {
         $exclude_query = ' ';

--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,9 @@ No questions so far, but don't hesitate to ask!
 
 == Changelog ==
 
+= 1.0.13 =
+* Option to exclude user from lists is missing from wp-admin - FIXED
+
 = 1.0.12 =
 * Filter added to wp_login_url() to filter change all login urls to the UWP one - CHANGED
 * Settings added to change subject & content for Password change notification - CHANGED


### PR DESCRIPTION
Fix #155 