### PR TITLE
Escape on apostrophe in text with visible slash - FIXED

### DIFF
--- a/includes/class-meta.php
+++ b/includes/class-meta.php
@@ -104,6 +104,7 @@ class UsersWP_Meta {
 
 
         $value = uwp_maybe_unserialize($key, $value);
+        $value = wp_unslash($value);
         $value = apply_filters( 'uwp_get_usermeta', $value, $user_id, $key, $default, $usermeta );
         return apply_filters( 'uwp_get_usermeta_' . $key, $value, $user_id, $key, $default, $usermeta );
     }

--- a/readme.txt
+++ b/readme.txt
@@ -119,6 +119,9 @@ No questions so far, but don't hesitate to ask!
 
 == Changelog ==
 
+= 1.0.14 =
+* Fix escape slashes in content of profile fields - FIXED
+
 = 1.0.13 =
 * Allow to change icon for fieldset while displaying as a profile tab - CHANGED
 * Option to exclude user from lists is missing from wp-admin - FIXED


### PR DESCRIPTION
Fix #200 