### PR TITLE
Added Group Descriptions to Exporters and updated Privacy Policy guide to drop use of deprecated classes

### DIFF
--- a/includes/class-uwp-privacy-exporters.php
+++ b/includes/class-uwp-privacy-exporters.php
@@ -23,10 +23,11 @@ class UsersWP_Privacy_Exporters {
 
         if ( $user instanceof WP_User ) {
             $data_to_export[] = array(
-                'group_id'    => 'uwp_user',
-                'group_label' => __( 'UsersWP User Data', 'userswp' ),
-                'item_id'     => 'user',
-                'data'        => self::get_user_meta_data( $user ),
+                'group_id'          => 'uwp_user',
+                'group_label'       => __( 'UsersWP User Data', 'userswp' ),
+                'group_description' => __( 'The UsersWP user data.', 'userswp' ),
+                'item_id'           => 'user',
+                'data'              => self::get_user_meta_data( $user ),
             );
         }
 

--- a/includes/class-uwp-privacy.php
+++ b/includes/class-uwp-privacy.php
@@ -33,10 +33,9 @@ class UsersWP_Privacy extends UsersWP_Abstract_Privacy {
      * @since 1.0.14
      */
     public function get_privacy_message() {
-        $content = '<h2>' . __( 'User data/profile', 'userswp' ) . '</h2>' .
-                   '<div contenteditable="false">' .
-                   '<p class="wp-policy-help">' . __( 'Example privacy texts.', 'userswp' ) . '</p>' .
-                   '</div>' .
+        $content = '<div class="wp-suggested-text">' .
+                   '<h2>' . __( 'User data/profile', 'userswp' ) . '</h2>' .
+                   '<p class="privacy-policy-tutorial">' . __( 'Example privacy texts.', 'userswp' ) . '</p>' .
                    '<p>' . __( 'We collect information about you during the registration and edit profile process on our site. This information may include, but is not limited to, your name, email address, phone number, address, IP and any other details that might be requested from you for the purpose of building your public profile.', 'userswp' ) . '</p>' .
                    '<p>' . __( 'Handling this data also allows us to:', 'userswp' ) . '</p>' .
                    '<ul>' .
@@ -45,7 +44,8 @@ class UsersWP_Privacy extends UsersWP_Abstract_Privacy {
                    '<li>' . __( '- Respond to your queries or complaints.', 'userswp' ) . '</li>' .
                    '<li>' . __( '- Set up and administer your account, provide technical and/or customer support, and to verify your identity. We do this on the basis of our legitimate business interests.', 'userswp' ) . '</li>' .
                    '</ul>' .
-                   '<p>' . __( 'Any profile information provided to this site may be displayed publicly.', 'userswp' ) . '</p>';
+                   '<p>' . __( 'Any profile information provided to this site may be displayed publicly.', 'userswp' ) . '</p>' .
+                   '</div>';
 
         return apply_filters( 'uwp_privacy_policy_content', $content );
     }


### PR DESCRIPTION
Adds support for group_description for privacy exporters which was added in WP5.3 through [WPCoreChangeset#45825](https://core.trac.wordpress.org/changeset/45825) and [WPCoreTracTicket#45491](https://core.trac.wordpress.org/ticket/45491)

Update Suggested Privacy Policy text to utilize privacy-policy-tutorial css class instead of wp-policy-help as it was deprecated. Also wrap the contents in the wp-suggested-text div to style the section to match WordPress. This follows from [WPCoreTrac#49282](https://core.trac.wordpress.org/ticket/49282) and although back-compat is being introduced in WP5.4 as of [WPChangeset#47112](https://core.trac.wordpress.org/changeset/47112) this change will better support users of WP5.1-5.4

This also removes the wrapping `<div contenteditable="false">` as it's now unnecessary. As long as the content uses the proper privacy-policy-tutorial class then the WP Privacy Policy Guide section copy action will avoid copying that content. The contenteditable divs were there originally when the contents was fully copied due to not using the appropriate class, and when originally the entire guide would be dumped into the WYSIWYG editor with wp-policy-help sections being highlighted.