### PR TITLE
make all account icons equal

### DIFF
--- a/includes/helpers/misc.php
+++ b/includes/helpers/misc.php
@@ -634,7 +634,7 @@ function uwp_add_account_menu_links() {
             ?>
             <li class="nav-item m-0 p-0 list-unstyled mx-md-2 mx-2">
                 <a class="nav-link text-decoration-none uwp-account-<?php echo $tab_id.' '.$active; ?>" href="<?php echo esc_url( $tab_url ); ?>">
-                    <?php echo '<i class="'. esc_attr( $tab["icon"] ).' mr-1" style="width: 20px"></i>'. sanitize_text_field( $tab['title'] ); ?>
+                    <?php echo '<i class="'. esc_attr( $tab["icon"] ).' fa-fw mr-1"></i>'. sanitize_text_field( $tab['title'] ); ?>
                 </a>
             </li>
             <?php

--- a/includes/helpers/misc.php
+++ b/includes/helpers/misc.php
@@ -634,7 +634,7 @@ function uwp_add_account_menu_links() {
             ?>
             <li class="nav-item m-0 p-0 list-unstyled mx-md-2 mx-2">
                 <a class="nav-link text-decoration-none uwp-account-<?php echo $tab_id.' '.$active; ?>" href="<?php echo esc_url( $tab_url ); ?>">
-                    <?php echo '<i class="'.$tab["icon"].' mr-1"></i>'.$tab['title']; ?>
+                    <?php echo '<i class="'. esc_attr( $tab["icon"] ).' mr-1" style="width: 20px"></i>'. sanitize_text_field( $tab['title'] ); ?>
                 </a>
             </li>
             <?php


### PR DESCRIPTION
Some icons are bigger than others. This PR ensures that all icons on the accounts page are of equal widths.